### PR TITLE
Fix CLI call mismatch

### DIFF
--- a/src/gack/__main__.py
+++ b/src/gack/__main__.py
@@ -5,4 +5,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Privacy preserving home monitoring")
     parser.add_argument("--stream", action="store_true", help="Stream the video to the web")
     args = parser.parse_args()
-    main(args) 
+    # pose_stream.main currently does not accept arguments
+    # so we simply call it without passing parsed args
+    main()


### PR DESCRIPTION
## Summary
- correct main() invocation in CLI entry point

## Testing
- `python -m pytest tests/test_basic.py -q`
- `python -m pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6884c48b66788325951875d9844aa6a2