### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg libgl1 libsm6 libxext6 curl
-          curl -L https://github.com/bluenviron/mediamtx/releases/latest/download/mediamtx_linux_amd64.tar.gz -o mediamtx.tar.gz
+          curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
           sudo tar -xzf mediamtx.tar.gz mediamtx
           sudo mv mediamtx /usr/local/bin/
           rm mediamtx.tar.gz
 
       - name: Install Rye
         run: |
-          curl -sSf https://rye-up.com/get | bash -s -- -y
-          echo "${HOME}/.rye/shims" >> $GITHUB_PATH
+          curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
+          echo 'source "$HOME/.rye/env"' >> ~/.profile
+          source "$HOME/.rye/env"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          rye sync
+          rye sync --no-lock
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libgl1 libsm6 libxext6 curl
+          curl -L https://github.com/bluenviron/mediamtx/releases/latest/download/mediamtx_linux_amd64.tar.gz -o mediamtx.tar.gz
+          sudo tar -xzf mediamtx.tar.gz mediamtx
+          sudo mv mediamtx /usr/local/bin/
+          rm mediamtx.tar.gz
+
+      - name: Install Rye
+        run: |
+          curl -sSf https://rye-up.com/get | bash -s -- -y
+          echo "${HOME}/.rye/shims" >> $GITHUB_PATH
+
+      - name: Install Python dependencies
+        run: |
+          rye sync
+
+      - name: Run tests
+        run: |
+          rye run pytest -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg libgl1 libsm6 libxext6 curl
-          curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
+            curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
           sudo tar -xzf mediamtx.tar.gz mediamtx
           sudo mv mediamtx /usr/local/bin/
           rm mediamtx.tar.gz
@@ -24,7 +24,7 @@ jobs:
         run: |
           curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
           echo 'source "$HOME/.rye/env"' >> ~/.profile
-          source "$HOME/.rye/env"
+          echo "$HOME/.rye/shims" >> $GITHUB_PATH
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## Summary
- run unit tests with GitHub Actions using rye
- install ffmpeg, opencv and mediamtx in the CI environment

## Testing
- `pip install -r requirements.lock --break-system-packages --ignore-installed`
- `pytest -q` *(fails: FileNotFoundError: No such file or directory: 'mediamtx')*

------
https://chatgpt.com/codex/tasks/task_e_6884c892be0883258c31df3dc9384577