### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg libgl1 libsm6 libxext6 curl
-            curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
+          curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
           sudo tar -xzf mediamtx.tar.gz mediamtx
           sudo mv mediamtx /usr/local/bin/
           rm mediamtx.tar.gz
@@ -30,6 +30,12 @@ jobs:
         run: |
           rye sync --no-lock
 
+      - name: Use CPU-only Torch
+        run: |
+          rye run pip install --no-deps torch==2.7.1+cpu torchvision==0.22.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+
       - name: Run tests
+        env:
+          CUDA_VISIBLE_DEVICES: ""
         run: |
           rye run pytest -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           rye sync --no-lock
 
+      - name: Ensure pip is available
+        run: |
+          rye run python -m ensurepip --upgrade
+
       - name: Use CPU-only Torch
         run: |
           rye run python -m pip install --no-deps torch==2.7.1+cpu torchvision==0.22.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install Rye
         run: |
           curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
-          echo 'source "$HOME/.rye/env"' >> ~/.profile
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
+          source "$HOME/.rye/env"
+          echo "$HOME/.rye/shims" >> "$GITHUB_PATH"
 
       - name: Install Python dependencies
         run: |
@@ -32,7 +32,7 @@ jobs:
 
       - name: Use CPU-only Torch
         run: |
-          rye run pip install --no-deps torch==2.7.1+cpu torchvision==0.22.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          rye run python -m pip install --no-deps torch==2.7.1+cpu torchvision==0.22.1+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
 
       - name: Run tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libgl1 libsm6 libxext6 curl
+            curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
+          sudo tar -xzf mediamtx.tar.gz mediamtx
+          sudo mv mediamtx /usr/local/bin/
+          rm mediamtx.tar.gz
+
+      - name: Install Rye
+        run: |
+          curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
+          echo 'source "$HOME/.rye/env"' >> ~/.profile
+          echo "$HOME/.rye/shims" >> $GITHUB_PATH
+
+      - name: Install Python dependencies
+        run: |
+          rye sync --no-lock
+
+      - name: Run tests
+        run: |
+          rye run pytest -vv


### PR DESCRIPTION
## Summary
- run unit tests with GitHub Actions using rye
- install ffmpeg, opencv and mediamtx in the CI environment
- fix mediamtx version and rye install per feedback
- avoid modifying the lock file when syncing dependencies

## Testing
- `rye sync --no-lock`
- `rye run pytest -q` *(fails: libcublas.so.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884c892be0883258c31df3dc9384577