### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libgl1 libsm6 libxext6 curl
+          curl -L https://github.com/bluenviron/mediamtx/releases/download/v1.13.1/mediamtx_v1.13.1_linux_amd64.tar.gz -o mediamtx.tar.gz
+          sudo tar -xzf mediamtx.tar.gz mediamtx
+          sudo mv mediamtx /usr/local/bin/
+          rm mediamtx.tar.gz
+
+      - name: Install Rye
+        run: |
+          curl -sSf https://rye.astral.sh/get | RYE_INSTALL_OPTION="--yes" bash
+          echo 'source "$HOME/.rye/env"' >> ~/.profile
+          source "$HOME/.rye/env"
+          echo "$HOME/.rye/shims" >> "$GITHUB_PATH"
+
+      - name: Install Python dependencies
+        run: |
+          rye sync --no-lock
+
+      - name: Ensure pip is available
+        run: |
+          rye run python -m ensurepip --upgrade
+
+      - name: Use CPU-only Torch
+        run: |
+          rye run python -m pip install --force-reinstall --no-deps \
+            torch==2.7.1 torchvision==0.22.1 \
+            --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Run tests
+        env:
+          CUDA_VISIBLE_DEVICES: ""
+        run: |
+          rye run pytest -vv


### PR DESCRIPTION
## Summary
- fix Rye install command so it doesn't specify a Python version
- reinstall CPU-only torch before running the tests

## Testing
- `rye sync --no-lock`
- `rye run python -m ensurepip --upgrade`
- `rye run python -m pip install --force-reinstall --no-deps --index-url https://download.pytorch.org/whl/cpu torch==2.7.1 torchvision==0.22.1`
- `CUDA_VISIBLE_DEVICES='' rye run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c892be0883258c31df3dc9384577